### PR TITLE
feat: add customisable guild configuration

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,3 +13,77 @@ datasource db {
 model botBlacklist {
   id String @id
 }
+
+model GuildConfig {
+  id      String         @id
+  automod AutoModConfig? @relation("automod")
+  logging LoggingConfig? @relation("logging")
+}
+
+model AutoModConfig {
+  guildId String      @unique
+  guild   GuildConfig @relation("automod", fields: [guildId], references: [id])
+
+  moduleEnabled Boolean @default(false)
+  MuteDuration  Int     @default(600) // duration in seconds (max 24 hours)
+
+  inviteEnabled   Boolean          @default(true)
+  inviteDelete    Boolean          @default(true)
+  inviteAction    ModerationAction @default(WARN)
+  inviteWhitelist String[]
+
+
+  DupTextEnabled   Boolean          @default(true)
+  DupTextDelete    Boolean          @default(false)
+  DupTextAction    ModerationAction @default(VERBAL)
+  DupTextWhitelist String[]
+
+  SpamEnabled   Boolean          @default(true)
+  SpamDelete    Boolean          @default(true)
+  SpamAction    ModerationAction @default(MUTE)
+  SpamWhitelist String[]
+
+  PhishingEnabled   Boolean          @default(true)
+  PhishingDelete    Boolean          @default(true)
+  PhishingAction    ModerationAction @default(BAN)
+  PhishingWhitelist String[]
+
+  MassMentionEnabled   Boolean          @default(true)
+  MassMentionDelete    Boolean          @default(true)
+  MassMentionAction    ModerationAction @default(MUTE)
+  MassMentionWhitelist String[]
+
+  ZalgoEnabled   Boolean          @default(true)
+  ZalgoDelete    Boolean          @default(true)
+  ZalgoAction    ModerationAction @default(WARN)
+  ZalgoWhitelist String[]
+
+  BadwordsEnabled     Boolean          @default(true)
+  BadwordsDelete      Boolean          @default(true)
+  BadwordsAction      ModerationAction @default(WARN)
+  BadwordsWhitelist   String[]
+  BadwordsAllowedList String[] // whitelisted words
+  BadwordsBlockedList String[] // blacklisted words
+}
+
+model LoggingConfig {
+  guildId String      @unique
+  guild   GuildConfig @relation("logging", fields: [guildId], references: [id])
+
+  moduleEnabled Boolean @default(false)
+
+  messageEnabled Boolean @default(true)
+  messageChannel String?
+  messageWebhook String?
+
+  modEnabled Boolean @default(true)
+  modChannel String?
+  modWebhook String?
+}
+
+enum ModerationAction {
+  VERBAL
+  WARN
+  MUTE
+  BAN
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,7 +15,7 @@ model botBlacklist {
 }
 
 model GuildConfig {
-  id      String         @id
+  id      String         @id @unique
   automod AutoModConfig? @relation("automod")
   logging LoggingConfig? @relation("logging")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,8 +24,10 @@ model AutoModConfig {
   guildId String      @unique
   guild   GuildConfig @relation("automod", fields: [guildId], references: [id])
 
-  moduleEnabled Boolean @default(false)
-  MuteDuration  Int     @default(600) // duration in seconds (max 24 hours)
+  moduleEnabled   Boolean  @default(false)
+  MuteDuration    Int      @default(600) // duration in seconds (max 24 hours)
+  globalWhitelist String[]
+
 
   inviteEnabled   Boolean          @default(true)
   inviteDelete    Boolean          @default(true)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,9 +15,10 @@ model botBlacklist {
 }
 
 model GuildConfig {
-  id      String         @id @unique
-  automod AutoModConfig? @relation("automod")
-  logging LoggingConfig? @relation("logging")
+  id             String         @id @unique
+  leaveTimestamp DateTime?
+  automod        AutoModConfig? @relation("automod")
+  logging        LoggingConfig? @relation("logging")
 }
 
 model AutoModConfig {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,6 +44,8 @@ model AutoModConfig {
   SpamDelete    Boolean          @default(true)
   SpamAction    ModerationAction @default(MUTE)
   SpamWhitelist String[]
+  SpamDuration  Int              @default(5) // max 10s
+  SpamAmount    Int              @default(7) // max 20
 
   PhishingEnabled   Boolean          @default(true)
   PhishingDelete    Boolean          @default(true)
@@ -54,6 +56,8 @@ model AutoModConfig {
   MassMentionDelete    Boolean          @default(true)
   MassMentionAction    ModerationAction @default(MUTE)
   MassMentionWhitelist String[]
+  MassMentionDuration  Int              @default(5) // max 10s
+  MassMentionAmount    Int              @default(7) // max 20
 
   ZalgoEnabled   Boolean          @default(true)
   ZalgoDelete    Boolean          @default(true)

--- a/src/bot/listeners/Guild/GuildCreate.ts
+++ b/src/bot/listeners/Guild/GuildCreate.ts
@@ -12,7 +12,10 @@ export default class extends Listener {
 			select: { automod: true, logging: true, id: true }
 		});
 		if (!guildConfig)
-			guildConfig = await this.client.prisma.guildConfig.create({ data: { id: guild.id }, select: { automod: true, logging: true, id: true } });
+			guildConfig = await this.client.prisma.guildConfig.create({
+				data: { id: guild.id, automod: { create: {} }, logging: { create: {} } },
+				select: { automod: true, logging: true, id: true }
+			});
 		this.client.guildConfig.set(guild.id, guildConfig as unknown as FullGuildConfig);
 	}
 }

--- a/src/bot/listeners/Guild/GuildCreate.ts
+++ b/src/bot/listeners/Guild/GuildCreate.ts
@@ -1,4 +1,4 @@
-import { FullGuildConfig, Listener } from "../../../client";
+import { Listener } from "../../../client";
 import { ApplyOptions } from "@sapphire/decorators";
 import type { Guild } from "discord.js";
 
@@ -6,16 +6,6 @@ import type { Guild } from "discord.js";
 export default class extends Listener {
 	public async run(guild: Guild) {
 		this.container.logger.debug(`[GUILD]: New guild joined - ${guild.name} (${guild.id})`);
-
-		let guildConfig = await this.client.prisma.guildConfig.findUnique({
-			where: { id: guild.id },
-			select: { automod: true, logging: true, id: true }
-		});
-		if (!guildConfig)
-			guildConfig = await this.client.prisma.guildConfig.create({
-				data: { id: guild.id, automod: { create: {} }, logging: { create: {} } },
-				select: { automod: true, logging: true, id: true }
-			});
-		this.client.guildConfig.set(guild.id, guildConfig as unknown as FullGuildConfig);
+		await this.client.configManager.load(guild.id);
 	}
 }

--- a/src/bot/listeners/Guild/GuildCreate.ts
+++ b/src/bot/listeners/Guild/GuildCreate.ts
@@ -1,0 +1,18 @@
+import { FullGuildConfig, Listener } from "../../../client";
+import { ApplyOptions } from "@sapphire/decorators";
+import type { Guild } from "discord.js";
+
+@ApplyOptions<Listener.Options>({ event: "guildCreate" })
+export default class extends Listener {
+	public async run(guild: Guild) {
+		this.container.logger.debug(`[GUILD]: New guild joined - ${guild.name} (${guild.id})`);
+
+		let guildConfig = await this.client.prisma.guildConfig.findUnique({
+			where: { id: guild.id },
+			select: { automod: true, logging: true, id: true }
+		});
+		if (!guildConfig)
+			guildConfig = await this.client.prisma.guildConfig.create({ data: { id: guild.id }, select: { automod: true, logging: true, id: true } });
+		this.client.guildConfig.set(guild.id, guildConfig as unknown as FullGuildConfig);
+	}
+}

--- a/src/bot/listeners/Guild/GuildDelete.ts
+++ b/src/bot/listeners/Guild/GuildDelete.ts
@@ -1,0 +1,11 @@
+import { Listener } from "../../../client";
+import { ApplyOptions } from "@sapphire/decorators";
+import type { Guild } from "discord.js";
+
+@ApplyOptions<Listener.Options>({ event: "guildDelete" })
+export default class extends Listener {
+	public run(guild: Guild) {
+		this.container.logger.debug(`[GUILD]: Guild left - ${guild.name} (${guild.id})`);
+		void this.client.configManager.scheduleDelete(guild.id);
+	}
+}

--- a/src/bot/listeners/Ready.ts
+++ b/src/bot/listeners/Ready.ts
@@ -1,22 +1,10 @@
-import { FullGuildConfig, Listener } from "../../client";
+import { Listener } from "../../client";
 import { ApplyOptions } from "@sapphire/decorators";
 
 @ApplyOptions<Listener.Options>({ event: "ready", once: true })
 export default class extends Listener {
 	public run() {
 		this.container.logger.info(`${this.client.user!.tag} has logged in!`);
-
-		this.client.guilds.cache.forEach(async (guild) => {
-			let guildConfig = await this.client.prisma.guildConfig.findUnique({
-				where: { id: guild.id },
-				select: { automod: true, logging: true, id: true }
-			});
-			if (!guildConfig)
-				guildConfig = await this.client.prisma.guildConfig.create({
-					data: { id: guild.id, automod: { create: {} }, logging: { create: {} } },
-					select: { automod: true, logging: true, id: true }
-				});
-			this.client.guildConfig.set(guild.id, guildConfig as unknown as FullGuildConfig);
-		});
+		this.client.configManager.loadAll();
 	}
 }

--- a/src/bot/listeners/Ready.ts
+++ b/src/bot/listeners/Ready.ts
@@ -5,6 +5,6 @@ import { ApplyOptions } from "@sapphire/decorators";
 export default class extends Listener {
 	public run() {
 		this.container.logger.info(`${this.client.user!.tag} has logged in!`);
-		this.client.configManager.loadAll();
+		void this.client.configManager.loadAll();
 	}
 }

--- a/src/bot/listeners/Ready.ts
+++ b/src/bot/listeners/Ready.ts
@@ -1,9 +1,22 @@
-import { Listener } from "../../client";
+import { FullGuildConfig, Listener } from "../../client";
 import { ApplyOptions } from "@sapphire/decorators";
 
 @ApplyOptions<Listener.Options>({ event: "ready", once: true })
 export default class extends Listener {
 	public run() {
 		this.container.logger.info(`${this.client.user!.tag} has logged in!`);
+
+		this.client.guilds.cache.forEach(async (guild) => {
+			let guildConfig = await this.client.prisma.guildConfig.findUnique({
+				where: { id: guild.id },
+				select: { automod: true, logging: true, id: true }
+			});
+			if (!guildConfig)
+				guildConfig = await this.client.prisma.guildConfig.create({
+					data: { id: guild.id, automod: { create: {} }, logging: { create: {} } },
+					select: { automod: true, logging: true, id: true }
+				});
+			this.client.guildConfig.set(guild.id, guildConfig as unknown as FullGuildConfig);
+		});
 	}
 }

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,8 +1,9 @@
 import { SapphireClient } from "@sapphire/framework";
-import type { ActivitiesOptions, BitFieldResolvable, IntentsString, PartialTypes, PresenceStatusData } from "discord.js";
+import { ActivitiesOptions, BitFieldResolvable, Collection, IntentsString, PartialTypes, PresenceStatusData } from "discord.js";
 import { join } from "path";
 import { PrismaClient } from "@prisma/client";
 import { AutoMod, BlacklistManager, Utils, ServiceHandler } from "./lib";
+import type { FullGuildConfig } from "./";
 
 import "@daangamesdg/sapphire-logger/register";
 
@@ -19,6 +20,9 @@ export class Client extends SapphireClient {
 
 	// managers
 	public blacklistManager: BlacklistManager = new BlacklistManager(this);
+
+	// cache
+	public guildConfig = new Collection<string, FullGuildConfig>();
 
 	public constructor(options: ClientOptions) {
 		super({

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,9 +1,8 @@
 import { SapphireClient } from "@sapphire/framework";
-import { ActivitiesOptions, BitFieldResolvable, Collection, IntentsString, PartialTypes, PresenceStatusData } from "discord.js";
+import type { ActivitiesOptions, BitFieldResolvable, IntentsString, PartialTypes, PresenceStatusData } from "discord.js";
 import { join } from "path";
 import { PrismaClient } from "@prisma/client";
-import { AutoMod, BlacklistManager, Utils, ServiceHandler } from "./lib";
-import type { FullGuildConfig } from "./";
+import { AutoMod, BlacklistManager, Utils, ServiceHandler, ConfigManager } from "./lib";
 
 import "@daangamesdg/sapphire-logger/register";
 
@@ -20,9 +19,7 @@ export class Client extends SapphireClient {
 
 	// managers
 	public blacklistManager: BlacklistManager = new BlacklistManager(this);
-
-	// cache
-	public guildConfig = new Collection<string, FullGuildConfig>();
+	public configManager: ConfigManager = new ConfigManager(this);
 
 	public constructor(options: ClientOptions) {
 		super({

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,2 +1,3 @@
 export * from "./client";
 export * from "./lib";
+export * from "./types";

--- a/src/client/lib/managers/ConfigManager.ts
+++ b/src/client/lib/managers/ConfigManager.ts
@@ -109,7 +109,7 @@ export class ConfigManager {
 		const updated = await this.client.prisma.guildConfig.update({ where: { id }, data, select: { automod: true, id: true, logging: true } });
 		this.guildConfig.set(id, updated as FullGuildConfig);
 
-		return updated;
+		return updated as FullGuildConfig;
 	}
 
 	public scheduleDeleteAll() {
@@ -137,9 +137,11 @@ export class ConfigManager {
 		});
 	}
 
-	public scheduleDelete(id: string) {
-		const config = this.guildConfig.get(id);
+	public async scheduleDelete(id: string) {
+		let config = this.guildConfig.get(id)!;
 		if (!config || this.timeouts.has(id)) return;
+
+		config = await this.update(config.id, { leaveTimestamp: new Date() });
 
 		const getTime = () => {
 			const futureDate = config.leaveTimestamp!.getMilliseconds() + 6048e5;

--- a/src/client/lib/managers/ConfigManager.ts
+++ b/src/client/lib/managers/ConfigManager.ts
@@ -128,10 +128,11 @@ export class ConfigManager {
 					data: { automod: { delete: true }, logging: { delete: true } }
 				});
 				await this.client.prisma.guildConfig.delete({ where: { id: config.id } });
-				this.guildConfig.delete(config.id);
+
 				this.timeouts.delete(config.id);
 			}, getTime());
 
+			this.guildConfig.delete(config.id);
 			this.timeouts.set(config.id, { timeout, id: config.id });
 		});
 	}
@@ -153,10 +154,10 @@ export class ConfigManager {
 				data: { automod: { delete: true }, logging: { delete: true } }
 			});
 			await this.client.prisma.guildConfig.delete({ where: { id: config.id } });
-			this.guildConfig.delete(config.id);
 			this.timeouts.delete(config.id);
 		}, getTime());
 
+		this.guildConfig.delete(config.id);
 		this.timeouts.set(config.id, { timeout, id: config.id });
 	}
 }

--- a/src/client/lib/managers/ConfigManager.ts
+++ b/src/client/lib/managers/ConfigManager.ts
@@ -100,6 +100,12 @@ export class ConfigManager {
 				select: { automod: true, logging: true, id: true }
 			});
 		this.guildConfig.set(guildId, guildConfig as unknown as FullGuildConfig);
+
+		const timeout = this.timeouts.get(guildId);
+		if (timeout) {
+			clearTimeout(timeout.timeout);
+			this.timeouts.delete(guildId);
+		}
 	}
 
 	public get(id: string): FullGuildConfig {

--- a/src/client/lib/managers/ConfigManager.ts
+++ b/src/client/lib/managers/ConfigManager.ts
@@ -1,0 +1,105 @@
+import { Collection } from "discord.js";
+import type { Client } from "../..";
+import type { FullGuildConfig } from "../../types";
+
+const getMockConfig = (id: string): FullGuildConfig => ({
+	automod: {
+		guildId: id,
+		moduleEnabled: false,
+		MuteDuration: 6e2,
+		globalWhitelist: [],
+		inviteEnabled: true,
+		inviteDelete: true,
+		inviteAction: "WARN",
+		inviteWhitelist: [],
+		DupTextEnabled: true,
+		DupTextDelete: false,
+		DupTextAction: "VERBAL",
+		DupTextWhitelist: [],
+		SpamEnabled: true,
+		SpamDelete: true,
+		SpamAction: "MUTE",
+		SpamWhitelist: [],
+		SpamDuration: 5,
+		SpamAmount: 7,
+		PhishingEnabled: true,
+		PhishingDelete: true,
+		PhishingAction: "BAN",
+		PhishingWhitelist: [],
+		MassMentionEnabled: true,
+		MassMentionDelete: true,
+		MassMentionAction: "MUTE",
+		MassMentionWhitelist: [],
+		MassMentionDuration: 5,
+		MassMentionAmount: 7,
+		ZalgoEnabled: true,
+		ZalgoDelete: true,
+		ZalgoAction: "WARN",
+		ZalgoWhitelist: [],
+		BadwordsEnabled: true,
+		BadwordsDelete: true,
+		BadwordsAction: "WARN",
+		BadwordsWhitelist: [],
+		BadwordsAllowedList: [],
+		BadwordsBlockedList: []
+	},
+	logging: {
+		guildId: id,
+		moduleEnabled: false,
+		messageEnabled: true,
+		messageChannel: null,
+		messageWebhook: null,
+		modEnabled: true,
+		modChannel: null,
+		modWebhook: null
+	},
+	id
+});
+
+export class ConfigManager {
+	public guildConfig = new Collection<string, FullGuildConfig>();
+
+	public constructor(public client: Client) {}
+
+	public loadAll() {
+		this.client.guilds.cache.forEach(async (guild) => {
+			let guildConfig = await this.client.prisma.guildConfig.findUnique({
+				where: { id: guild.id },
+				select: { automod: true, logging: true, id: true }
+			});
+			if (!guildConfig)
+				guildConfig = await this.client.prisma.guildConfig.create({
+					data: { id: guild.id, automod: { create: {} }, logging: { create: {} } },
+					select: { automod: true, logging: true, id: true }
+				});
+			this.guildConfig.set(guild.id, guildConfig as unknown as FullGuildConfig);
+		});
+	}
+
+	public async load(guildId: string) {
+		let guildConfig = await this.client.prisma.guildConfig.findUnique({
+			where: { id: guildId },
+			select: { automod: true, logging: true, id: true }
+		});
+		if (!guildConfig)
+			guildConfig = await this.client.prisma.guildConfig.create({
+				data: { id: guildId, automod: { create: {} }, logging: { create: {} } },
+				select: { automod: true, logging: true, id: true }
+			});
+		this.guildConfig.set(guildId, guildConfig as unknown as FullGuildConfig);
+	}
+
+	public get(id: string): FullGuildConfig {
+		const config = this.guildConfig.get(id);
+		if (!config) return getMockConfig(id);
+
+		return config;
+	}
+
+	public async update(id: string, data: Partial<FullGuildConfig>) {
+		const updated = await this.client.prisma.guildConfig.update({ where: { id }, data, select: { automod: true, id: true, logging: true } });
+		this.guildConfig.set(id, updated as FullGuildConfig);
+
+		return updated;
+	}
+}

--- a/src/client/lib/managers/ConfigManager.ts
+++ b/src/client/lib/managers/ConfigManager.ts
@@ -81,6 +81,8 @@ export class ConfigManager {
 				});
 			this.guildConfig.set(guild.id, guildConfig as unknown as FullGuildConfig);
 		});
+
+		this.scheduleDeleteAll();
 	}
 
 	public async load(guildId: string) {

--- a/src/client/lib/managers/index.ts
+++ b/src/client/lib/managers/index.ts
@@ -1,1 +1,2 @@
 export * from "./BlacklistManager";
+export * from "./ConfigManager";

--- a/src/client/lib/structures/Moderation/AutoMod.ts
+++ b/src/client/lib/structures/Moderation/AutoMod.ts
@@ -31,7 +31,7 @@ export class AutoMod {
 
 		if (message.author.bot || message.webhookId) return;
 
-		const config = this.client.guildConfig.get(message.guildId)!;
+		const config = this.client.configManager.get(message.guildId);
 		if (!this.shouldAdd(message, config.automod.globalWhitelist)) return;
 
 		const badwordsConfig = { blacklisted: config.automod.BadwordsBlockedList, whitelisted: config.automod.BadwordsAllowedList };

--- a/src/client/lib/structures/Moderation/types.ts
+++ b/src/client/lib/structures/Moderation/types.ts
@@ -47,3 +47,5 @@ export interface phishingLinksData {
 	suspicious: string[];
 	guaranteed: string[];
 }
+
+export type AutoModModuleFunctionResult = Promise<AutoModResults | null> | (AutoModResults | null);

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,3 +1,6 @@
 import type { AutoModConfig, GuildConfig, LoggingConfig } from "@prisma/client";
 
-export type FullGuildConfig = GuildConfig & AutoModConfig & LoggingConfig;
+export type FullGuildConfig = GuildConfig & {
+	automod: AutoModConfig;
+	logging: LoggingConfig;
+};

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,0 +1,3 @@
+import type { AutoModConfig, GuildConfig, LoggingConfig } from "@prisma/client";
+
+export type FullGuildConfig = GuildConfig & AutoModConfig & LoggingConfig;


### PR DESCRIPTION
### Please describe the changes this PR makes:
- Adds guild config schema's
- Adds event listeners for guild (to update the schema's)
- Updates the automod handler to work with the config
- Adds config setting commands (**without translations, those are for a separate PR**)
- Adds a taskHandler to handle scheduled tasks

---
### To do list:
- [x] Guild Config
  - [x] Updated Prisma schema's
  - [x] Guild event listeners
    - [x] guildCreate event
    - [x] guildDelete event
  - [x] GuildConfig delete task
  - [x] Updated automod
- [x] ~Commands~ => too many settings, will get too complicated/messy.
