### PR TITLE
refactor: use custom locales instead of guild.preferredLocale

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,10 +15,12 @@ model botBlacklist {
 }
 
 model GuildConfig {
-  id             String         @id @unique
+  id             String    @id @unique
   leaveTimestamp DateTime?
-  automod        AutoModConfig? @relation("automod")
-  logging        LoggingConfig? @relation("logging")
+  locale         String    @default("en")
+
+  automod AutoModConfig? @relation("automod")
+  logging LoggingConfig? @relation("logging")
 }
 
 model AutoModConfig {
@@ -76,7 +78,6 @@ model AutoModConfig {
 model LoggingConfig {
   guildId String      @unique
   guild   GuildConfig @relation("logging", fields: [guildId], references: [id])
-  locale  String      @default("en")
 
   moduleEnabled Boolean @default(false)
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -76,6 +76,7 @@ model AutoModConfig {
 model LoggingConfig {
   guildId String      @unique
   guild   GuildConfig @relation("logging", fields: [guildId], references: [id])
+  locale  String      @default("en")
 
   moduleEnabled Boolean @default(false)
 

--- a/src/bot/commands/General/HelpCommand.ts
+++ b/src/bot/commands/General/HelpCommand.ts
@@ -51,7 +51,7 @@ export default class extends Command {
 	}
 
 	public async messageRun(message: Message, args: Command.Args): Promise<void> {
-		const locale = message.guild?.preferredLocale || "en";
+		const { locale } = this.client.configManager.get(message?.guildId ?? "");
 		const cmd = await args.pickResult("string");
 		const command = this.container.stores.get("commands").get(cmd.value ?? "") as Command | undefined;
 

--- a/src/bot/commands/General/PingCommand.ts
+++ b/src/bot/commands/General/PingCommand.ts
@@ -13,7 +13,7 @@ import type { CommandInteraction, Message } from "discord.js";
 })
 export default class extends Command {
 	public async messageRun(message: Message): Promise<void> {
-		const locale = message.guild?.preferredLocale || "en";
+		const { locale } = this.client.configManager.get(message?.guildId ?? "");
 		const msg = await message.reply(this.getTranslations("loading", locale));
 		await msg.edit(
 			this.getTranslations("response", locale, { heartbeat: this.client.ws.ping, roundtrip: msg.createdTimestamp - message.createdTimestamp })

--- a/src/client/lib/managers/ConfigManager.ts
+++ b/src/client/lib/managers/ConfigManager.ts
@@ -54,7 +54,8 @@ const getMockConfig = (id: string): FullGuildConfig => ({
 		modWebhook: null
 	},
 	id,
-	leaveTimestamp: null
+	leaveTimestamp: null,
+	locale: "en"
 });
 
 interface ConfigTimeout {

--- a/src/client/lib/structures/Logging/MessageLogger.ts
+++ b/src/client/lib/structures/Logging/MessageLogger.ts
@@ -18,7 +18,7 @@ export class MessageLogger {
 
 	public onMessageDelete(message: GuildMessage) {
 		if (message.author.bot || message.webhookId) return;
-		const locale = message.guild.preferredLocale;
+		const { locale } = this.client.configManager.get(message.guildId);
 
 		const embed = this.client.utils
 			.embed()
@@ -44,7 +44,7 @@ export class MessageLogger {
 
 	public onMessageUpdate(messageOld: GuildMessage, messageNew: GuildMessage) {
 		if (messageOld.content === messageNew.content || messageNew.author.bot || messageNew.webhookId) return;
-		const locale = messageNew.guild.preferredLocale;
+		const { locale } = this.client.configManager.get(messageNew.guildId);
 
 		const embed = this.client.utils
 			.embed()
@@ -83,7 +83,7 @@ export class MessageLogger {
 		if (!messages.size) return;
 
 		const message = messages.first()!;
-		const locale = message.guild.preferredLocale;
+		const { locale } = this.client.configManager.get(message.guildId);
 		const embed = this.client.utils.embed().setColor(EMBED_DANGER);
 
 		const title = this.t(locale, "logging:message.delete_bulk.title", {


### PR DESCRIPTION
### Please describe the changes this PR makes:
- Removes the usage of guild.preferredLocale in favour of custom one
⤷ guild.prefferedLocale **is only for community enabled servers**, we should also cover non-community servers by allowing them to specify their own custom locale

### Linked Issues:
closes #15 

---
<!--
### To do list:
- [ ] list item 1
  - [ ] list item 2
    - [ ] list item 3
-->
